### PR TITLE
Fixed "endsAt" case

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -48,7 +48,7 @@ type Alert struct {
 	Labels       map[string]string `json:"labels"`
 	Annotations  map[string]string `json:"annotations"`
 	StartsAt     string            `json:"startsAt,omitempty"`
-	EndsAt       string            `json:"EndsAt,omitempty"`
+	EndsAt       string            `json:"endsAt,omitempty"`
 	GeneratorURL string            `json:"generatorURL"`
 }
 


### PR DESCRIPTION
Make json field name compatible with https://prometheus.io/docs/alerting/configuration/#%3Cwebhook_config%3E

See https://github.com/gmauleon/alertmanager-zabbix-webhook/issues/2