### PR TITLE
Adding zabbixHostDefault option for unannotated alerts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,9 @@ queueCapacity: 500
 zabbixServerHost: zabbix-server-here
 # Trapper port of your zabbix server
 zabbixServerPort: 10051
-# Look in this annotation for a zabbix host to send alerts to, if not present alert is ignored
+# Look in this annotation for a zabbix host to send alerts to, if not present and no default, alert is ignored
 zabbixHostAnnotation: zabbix_host
+# Default host to attach to alerts
+zabbixHostDefault: ""
 # Items key prefix, keys will be zabbixKeyPrefix.alertname
 zabbixKeyPrefix: prometheus

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ queueCapacity: 500
 zabbixServerHost: zabbix-server-here
 # Trapper port of your zabbix server
 zabbixServerPort: 10051
-# Look in this annotation for a zabbix host to send alerts to, if not present and no default, alert is ignored
+# Look in this annotation for a zabbix host to send alerts to, if not present and no zabbixHostDefault is defined then alert will be ignored
 zabbixHostAnnotation: zabbix_host
 # Default host to attach to alerts
 zabbixHostDefault: ""

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ zabbixServerHost: zabbix-server-here
 zabbixServerPort: 10051
 # Look in this annotation for a zabbix host to send alerts to, if not present and no zabbixHostDefault is defined then alert will be ignored
 zabbixHostAnnotation: zabbix_host
-# Default host to attach to alerts
+# Default host to send alerts to
 zabbixHostDefault: ""
 # Items key prefix, keys will be zabbixKeyPrefix.alertname
 zabbixKeyPrefix: prometheus

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -153,7 +153,7 @@ func (hook *WebHook) processAlerts() {
 			}
 
 			// Send alerts only if a host annotation is present or configuration is not nill
-			if host != "" || hook.config.ZabbixHostDefault != "" {
+			if host != "" {
 				key := fmt.Sprintf("%s.%s", hook.config.ZabbixKeyPrefix, strings.ToLower(a.Labels["alertname"]))
 				value := "0"
 				if a.Status == "firing" {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -75,6 +75,7 @@ func ConfigFromFile(filename string) (cfg *WebHookConfig, err error) {
 		ZabbixServerPort:     10051,
 		ZabbixHostAnnotation: "zabbix_host",
 		ZabbixKeyPrefix:      "prometheus",
+		ZabbixHostDefault:    "",
 	}
 
 	err = yaml.Unmarshal(configFile, &config)
@@ -148,12 +149,15 @@ func (hook *WebHook) processAlerts() {
 
 			host, _ := a.Annotations[hook.config.ZabbixHostAnnotation]
 
-			// Send alerts only if a host annotation is present
-			if host != "" {
+			// Send alerts only if a host annotation is present or configuration is not nill
+			if host != "" || hook.config.ZabbixHostDefault != "" {
 				key := fmt.Sprintf("%s.%s", hook.config.ZabbixKeyPrefix, strings.ToLower(a.Labels["alertname"]))
 				value := "0"
 				if a.Status == "firing" {
 					value = "1"
+				}
+				if host == "" {
+					host = hook.config.ZabbixHostDefault
 				}
 
 				log.Infof("added Zabbix metrics, host: '%s' key: '%s', value: '%s'", host, key, value)

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -147,7 +147,10 @@ func (hook *WebHook) processAlerts() {
 				return
 			}
 
-			host, _ := a.Annotations[hook.config.ZabbixHostAnnotation]
+			host, exists := a.Annotations[hook.config.ZabbixHostAnnotation]
+			if !exists {
+				host = hook.config.ZabbixHostDefault
+			}
 
 			// Send alerts only if a host annotation is present or configuration is not nill
 			if host != "" || hook.config.ZabbixHostDefault != "" {
@@ -155,9 +158,6 @@ func (hook *WebHook) processAlerts() {
 				value := "0"
 				if a.Status == "firing" {
 					value = "1"
-				}
-				if host == "" {
-					host = hook.config.ZabbixHostDefault
 				}
 
 				log.Infof("added Zabbix metrics, host: '%s' key: '%s', value: '%s'", host, key, value)


### PR DESCRIPTION
With many rules coming in from upstream sources like kube-prometheus or prometheus-operator helm charts. A useful option for us is to assign a default vhost under zabbix that represents a k8s cluster and raises alerts under it when no zabbix_host is defined or known.

zabbixHostDefault is used (if defined) if zabbixHostAnnotation is undefined